### PR TITLE
Export OTPInputProps from OTPInput entry point

### DIFF
--- a/src/OTPInput.tsx
+++ b/src/OTPInput.tsx
@@ -4,7 +4,7 @@ type AllowedInputTypes = "password" | "text" | "tel";
 type AllowedInputMode = "none" | "numeric" | "tel";
 type AllowedInputHeight = "auto" | "fit-content" | string;
 
-interface OTPInputProps {
+export interface OTPInputProps {
   numberOfInputs: number;
   onChange: (otp: string) => void;
   inputWidth?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
-import OTPInput from "./OTPInput";
+import OTPInput, { type OTPInputProps } from "./OTPInput";
 
-export { OTPInput };
+export { OTPInput, OTPInputProps };


### PR DESCRIPTION
This PR exports `OTPInputProps` from the OTPInput entry point, allowing users to import both the `OTPInput` component and its prop types from the same module.